### PR TITLE
fix: create CloudWatch log groups before RDS instance

### DIFF
--- a/cloudwatch_logs_exports.tf
+++ b/cloudwatch_logs_exports.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_group" "log_exports" {
   for_each = { for value in var.enabled_cloudwatch_logs_exports : value => value }
-  name     = "/aws/rds/instance/${aws_db_instance.this.identifier}/${each.key}"
+  name     = "/aws/rds/instance/${var.name}-master/${each.key}"
 
   retention_in_days = 60
   kms_key_id        = var.kms_key_arn


### PR DESCRIPTION
## Summary

- Replace `aws_db_instance.this.identifier` with `"${var.name}-master"` in `cloudwatch_logs_exports.tf`
- This removes the implicit dependency on `aws_db_instance.this`, so Terraform creates the log groups **before** the RDS instance
- AWS then reuses the existing log groups instead of auto-creating them alongside the RDS instance, eliminating the `ResourceAlreadyExistsException`

## Root cause

`aws_db_instance.this.identifier` is always equal to `"${var.name}-master"` (see `main.tf`), but referencing it forces Terraform to wait until the RDS instance exists before creating the log groups. By the time Terraform creates them, AWS has already auto-created them via `enabled_cloudwatch_logs_exports`.

## Test plan

- [ ] Deploy a new RDS instance — log groups should be created by Terraform first, no import blocks needed
- [ ] Verify existing instances show no planned changes (value of `name` attribute is identical)
- [ ] Verify log groups have correct retention (60 days) and KMS encryption after deploy